### PR TITLE
Do not crash on malformed record input data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,6 +625,7 @@ impl Store {
             let record = record?;
 
             if record[0].starts_with('#')
+                || record.len() < 8
                 || &record[5] == "summary"
                 || &record[6] == "reserved"
                 || &record[6] == "available"


### PR DESCRIPTION
Currently, if one of the delegated extended files returns e.g. a 404 HTML page, roto-api will crash as it cannot find index 5, 6, and 7 in the CSV. This adds a check to prevent that.